### PR TITLE
Fix: Installation description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-git clone https://github.com/otkrickey/react_sh-fes2021
+git clone https://github.com/sh-fes/react_sh-fes2021
 
 cd react_sh-fes2021
 
@@ -19,9 +19,3 @@ yarn install
 ```bash
 yarn start
 ```
-
-## ProgressNote
-
--   [x] Create React App
--   [x] Add Navigation Menu
--   [ ] ....


### PR DESCRIPTION
- プロジェクト名の変更に伴いclone先のurlを修正
- 現在の操作のみだとclientフォルダ内でエラーが発生するため操作を追記